### PR TITLE
fix: missing tags in Docker CD

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,3 +34,4 @@ jobs:
           context: .
           push: true
           labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
-  add `tags` to Build and push step